### PR TITLE
Downgrading discord.js to 8.1.0 from v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "CCPL",
   "dependencies": {
-    "discord.js": "hydrabolt/discord.js#indev",
+    "discord.js": "hydrabolt/discord.js#8.1.0",
     "request": ">=2.58.0",
     "underscore": "1.8.x",
     "winston": "1.0.x",


### PR DESCRIPTION
Currently the discord.js 'indev' branch is on discord.js version 9 that has multiple code breaking changes for their methods.

Reverting back to discord.js 8.1.0 will solve said issues when building for self-hosts. BitQuote had noted that he does not intend to update existing code, as AB v4 will be using discord.js v9.x.

[Source](http://hydrabolt.github.io/discord.js/#!/docs/tag/master/file/general/Updating%20your%20code)