### PR TITLE
Change .json save data from single-line output to pretty output

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -8322,9 +8322,9 @@ function saveData(file, callback) {
             object = logs;
             break;
     }
-    writeFileAtomic(file, JSON.stringify(object), {chown:{uid: 100, gid: 50}}, function(error) {
+    writeFileAtomic(file, JSON.stringify(object, undefined, 2), {chown:{uid: 100, gid: 50}}, function(error) {
         if(error) {
-            fs.writeFile(file, JSON.stringify(object), function(err) {
+            fs.writeFile(file, JSON.stringify(object, undefined, 2), function(err) {
                 callback(err);
             });
         } else {


### PR DESCRIPTION
We had a discussion in the #self-hosts Discord channel about .json config files being saved as a single line versus 'pretty printed' json.
Since it's somewhat annoying to edit the config files after they've been paved over by the bot I decided to take a look.

It looks like the only files a user would want to edit are the ones written by the `saveData` function, this is a simple update to add two-space indentation to those .json files to match the format in the repo.

Reference: [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)